### PR TITLE
fix: string support interpolation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "bin": {
     "locales-generator": "./build/cli.js"
   },
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A handful util to generate and merge if exists already locale file for @angular/localize package",
   "main": "./build/cli.js",
   "scripts": {


### PR DESCRIPTION
This fix would successfully parse the following source <source>Hi, <x id="INTERPOLATION" equiv-text="{{ name }}"/>! LL</source>

fix for https://github.com/featbit/angular-locales-generator/issues/1